### PR TITLE
Fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ spockpy is primarily built on [OpenCV](http://opencv.org) for a large number of 
 
 For Linux users, use our build scripts as follows:
 ```console
-$ chnmod +x build/*
+$ chmod +x build/*
 $ build/get-opencv.sh
 ```
 


### PR DESCRIPTION
In ReadME, to install for linux users, there was a typo.  

It was like **chnmod**
Where i changed it to  **chmod**

Hth :)